### PR TITLE
会員登録とログイン画面の実装

### DIFF
--- a/lib/features/registration/view/concept_screen.dart
+++ b/lib/features/registration/view/concept_screen.dart
@@ -1,3 +1,5 @@
+import 'package:chat_app/features/registration/view/login_screen.dart';
+import 'package:chat_app/features/registration/view/signup_screen.dart';
 import 'package:chat_app/widgets/button/app_button.dart';
 import 'package:flutter/material.dart';
 
@@ -30,6 +32,14 @@ class ConceptScreen extends StatelessWidget {
                     label: '会員登録', // 実装した引数に文字列を渡している。文字だけ異なるため共通利用する例。
                     onTap: () {
                       // ボタンが押された際のアクションはここに書く。
+                      // SignupScreenを開く。
+                      Navigator.of(context).push(
+                        MaterialPageRoute<SignupScreen>(
+                          builder: (_) {
+                            return const SignupScreen();
+                          },
+                        ),
+                      );
                     },
                   ),
                   const SizedBox(
@@ -39,7 +49,16 @@ class ConceptScreen extends StatelessWidget {
                   AppButton(
                     label: 'ログイン',
                     reverse: true,
-                    onTap: () {},
+                    onTap: () {
+                      // LoginScreenを開く。
+                      Navigator.of(context).push(
+                        MaterialPageRoute<LoginScreen>(
+                          builder: (_) {
+                            return const LoginScreen();
+                          },
+                        ),
+                      );
+                    },
                   ),
                   const SizedBox(height: 32),
                 ],

--- a/lib/features/registration/view/login_screen.dart
+++ b/lib/features/registration/view/login_screen.dart
@@ -1,0 +1,149 @@
+import 'package:chat_app/widgets/button/app_button.dart';
+import 'package:flutter/material.dart';
+
+// StatefulWidgetを使った場合のログイン画面
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  // メールアドレスとパスワードを入力するためのTextEditingControllerを定義
+  // lateは変数の遅延初期化を定義。TextControllerを実際に使用する前に変数を定義
+  late TextEditingController emailTextController;
+  late TextEditingController passwordTextController;
+
+  final formKey = GlobalKey<FormState>();
+
+  @override
+  void initState() {
+    print('画面が表示されたタイミング');
+    // initStateは画面が表示される一番最初に1度だけ呼び出される。
+
+    super.initState();
+    // lateで定義していたTextEditingControllerを画面を開く際に代入し初期化。
+    emailTextController = TextEditingController();
+    passwordTextController = TextEditingController();
+
+    // 初期値を設定（必要に応じて）
+    emailTextController.text = "初期値";
+  }
+
+  @override
+  void dispose() {
+    print('画面が破棄されたタイミング');
+    // disposeはStatefulWidgetが破棄されるときに呼び出される
+    // emailTextController.dispose()でTextEditingControllerをリソース破棄し解放する。
+    // disposeしないとTextControllerが内部で持っている情報が残り続ける。
+    // また再度開き直した場合、前回のTextControllerの情報は残り続け、２つ状態を持ち続けること
+    // になり、メモリを消費してしまう。
+    emailTextController.dispose();
+    passwordTextController.dispose();
+
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('ログイン'),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          // 画面が小さく溢れた場合はスクロールする。
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Column(
+              children: [
+                const SizedBox(height: 24),
+                const Text(
+                  'メールアドレス・パスワード\nを入力してください。',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 14,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 150),
+                Form(
+                  // Formウィジェットは、child内にある複数のフォームフィールド（TextFormFieldなど）をまとめて管理。
+                  // keyセットしたformKeyがこのFormに紐付いている。
+                  key: formKey,
+                  child: Column(
+                    children: [
+                      TextFormField(
+                        controller: emailTextController,
+                        // TextInputType.emailAddressはキーボードがemail入力に適した種類になる。
+                        keyboardType: TextInputType.emailAddress,
+                        decoration: InputDecoration(
+                          labelText: 'メールアドレス',
+                        ),
+                        validator: (value) {
+                          // バリデーションの定義を記載。valueは入力されている文字列。
+                          if (value == null || value.isEmpty) {
+                            return 'メールアドレスを入力してください';
+                          }
+                          // 入力された文字に@が含まれているかどうか。
+                          // 問題がない場合はnullを返す
+                          if (!value.contains('@')) {
+                            return '有効なメールアドレスを入力してください';
+                          }
+                          return null;
+                        },
+                      ),
+                      const SizedBox(height: 16),
+                      TextFormField(
+                        controller: passwordTextController,
+                        obscureText: true, // パスワードを非表示にする
+                        // TextInputType.visiblePasswordはキーボードがパスワード入力に適した種類になる。
+                        keyboardType: TextInputType.visiblePassword,
+                        decoration: InputDecoration(
+                          labelText: 'パスワード',
+                        ),
+                        validator: (value) {
+                          if (value == null || value.isEmpty) {
+                            return 'パスワードを入力してください。';
+                          }
+                          if (value.length < 5) {
+                            return 'パスワードは5文字以上入力してください。';
+                          }
+                          return null;
+                        },
+                      ),
+                      const SizedBox(height: 60),
+                      const SizedBox(height: 16),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                        ),
+                        child: AppButton(
+                          label: '登録',
+                          onTap: () {
+                            // formKeyを使ってTextFormFieldのvalidatorを実行
+                            // 問題ない場合はtrueを問題ある場合はfalseを返す。
+                            final validate = formKey.currentState!.validate();
+                            if (validate) {
+                              // 入力されたメールアドレスを取得
+                              final inputEmail = emailTextController.text;
+                              // 入力されたパスワードを取得
+                              final inputPassword = emailTextController.text;
+                              print('入力されたメールアドレス$inputEmail');
+                              print('入力されたパスワード$inputPassword');
+                            }
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/registration/view/login_screen.dart
+++ b/lib/features/registration/view/login_screen.dart
@@ -45,6 +45,9 @@ class _LoginScreenState extends State<LoginScreen> {
     super.dispose();
   }
 
+  // 入力中のメールアドレス表示するために保持する変数
+  String emailText = '';
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -67,6 +70,8 @@ class _LoginScreenState extends State<LoginScreen> {
                   ),
                   textAlign: TextAlign.center,
                 ),
+                SizedBox(height: 24),
+                Text(emailText),
                 const SizedBox(height: 150),
                 Form(
                   // Formウィジェットは、child内にある複数のフォームフィールド（TextFormFieldなど）をまとめて管理。
@@ -92,6 +97,13 @@ class _LoginScreenState extends State<LoginScreen> {
                             return '有効なメールアドレスを入力してください';
                           }
                           return null;
+                        },
+                        onChanged: (value) {
+                          // onChangedがリアルタイムで入力中の文字列を返すメソッド。
+                          setState(() {
+                            // setStateを呼び出すと画面が再描画され画面が更新される。
+                            emailText = value;
+                          });
                         },
                       ),
                       const SizedBox(height: 16),

--- a/lib/features/registration/view/signup_screen.dart
+++ b/lib/features/registration/view/signup_screen.dart
@@ -1,0 +1,113 @@
+import 'package:chat_app/widgets/button/app_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+// HookWidgetを使った場合の会員登録画面
+// HookWidgetを使うとStatefulWidgetで実装するinitStateやdisposeを
+// 書く必要はありません。
+class SignupScreen extends HookWidget {
+  const SignupScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // useTextEditingControllerはStatefulWidgetで行っていたinitState(初期化)やdispose(破棄)
+    // を自動で行ってくれるので1行で済みます。
+    final emailTextController = useTextEditingController(text: '初期値');
+    final passwordTextController = useTextEditingController();
+    final formKey = useMemoized(GlobalKey<FormState>.new);
+
+    // もしStatefulWidgetと同じように画面の表示と破棄されたタイミングを取りたい場合は
+    // useEffectを記載する。
+    useEffect(() {
+      print('画面が表示されたタイミング');
+      return () {
+        print('画面が破棄されたタイミング');
+      };
+    }, const []);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('会員登録'),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Column(
+              children: [
+                const SizedBox(height: 24),
+                const Text(
+                  'ログイン時に必要なメールアドレス・パスワード\nを入力してユーザー登録してください。',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 14,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 150),
+                Form(
+                  key: formKey,
+                  child: Column(
+                    children: [
+                      TextFormField(
+                        controller: emailTextController,
+                        decoration: InputDecoration(
+                          labelText: 'メールアドレス',
+                        ),
+                        validator: (value) {
+                          if (value == null || value.isEmpty) {
+                            return 'メールアドレスを入力してください';
+                          }
+                          if (!value.contains('@')) {
+                            return '有効なメールアドレスを入力してください';
+                          }
+                          return null;
+                        },
+                      ),
+                      const SizedBox(height: 16),
+                      TextFormField(
+                        controller: passwordTextController,
+                        obscureText: true, // パスワードを非表示にする
+                        decoration: InputDecoration(
+                          labelText: 'パスワード',
+                        ),
+                        validator: (value) {
+                          if (value == null || value.isEmpty) {
+                            return 'パスワードを入力してください。';
+                          }
+                          if (value.length < 5) {
+                            return 'パスワードは5文字以上入力してください。';
+                          }
+                          return null;
+                        },
+                      ),
+                      const SizedBox(height: 60),
+                      const SizedBox(height: 16),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                        ),
+                        child: AppButton(
+                          label: '登録',
+                          onTap: () {
+                            final validate = formKey.currentState!.validate();
+                            if (validate) {
+                              final inputEmail = emailTextController.text;
+                              final inputPassword = emailTextController.text;
+                              print('入力されたメールアドレス$inputEmail');
+                              print('入力されたパスワード$inputPassword');
+                            }
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/registration/view/signup_screen.dart
+++ b/lib/features/registration/view/signup_screen.dart
@@ -25,6 +25,9 @@ class SignupScreen extends HookWidget {
       };
     }, const []);
 
+    // 入力中のメールアドレス表示するために保持する変数
+    final emailText = useState<String>('');
+
     return Scaffold(
       appBar: AppBar(
         title: Text('会員登録'),
@@ -44,6 +47,8 @@ class SignupScreen extends HookWidget {
                   ),
                   textAlign: TextAlign.center,
                 ),
+                SizedBox(height: 24),
+                Text(emailText.value),
                 const SizedBox(height: 150),
                 Form(
                   key: formKey,
@@ -62,6 +67,10 @@ class SignupScreen extends HookWidget {
                             return '有効なメールアドレスを入力してください';
                           }
                           return null;
+                        },
+                        onChanged: (value) {
+                          // emailTextに代入。
+                          emailText.value = value;
                         },
                       ),
                       const SizedBox(height: 16),

--- a/lib/widgets/button/app_button.dart
+++ b/lib/widgets/button/app_button.dart
@@ -21,7 +21,6 @@ class AppButton extends StatelessWidget {
       // GestureDetectorで囲み、onTapを設定するとGestureDetectorのchildを押されたら
       // onTapが反応する
       onTap: () {
-        print('タップしました。');
         onTap();
       },
       child: Container(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -62,6 +62,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_hooks:
+    dependency: "direct main"
+    description:
+      name: flutter_hooks
+      sha256: cde36b12f7188c85286fba9b38cc5a902e7279f36dd676967106c041dc9dde70
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.5"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  flutter_hooks: ^0.20.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### 実装

見た目は同じ。

会員登録の画面はHookWidgetを使用。
ログイン画面はStatefulWidgetを使用。

StatefulWidgetはFlutterの状態管理の１つ。
HookWidgetはhttps://pub.dev/packages/flutter_hooks のライブラリを使った状態管理。

|会員登録|ログイン|
|---|---|
|<img src="https://github.com/user-attachments/assets/87ea20b9-d9dd-4282-b642-958d6ae268e0" width="300">|<img src="https://github.com/user-attachments/assets/bdcddd47-8e37-4f74-9f06-caf0756286ba" width="300">|


