### PR TITLE
アプリ起動時の初期化実装

### DIFF
--- a/lib/features/app_entry/controller/app_entry_controller.dart
+++ b/lib/features/app_entry/controller/app_entry_controller.dart
@@ -20,17 +20,21 @@ class AppEntryController extends StateNotifier<AsyncValue<UserStatus>> {
 
   Future<void> _initState() async {
     // ローディング画面がわかりやすいように2秒遅延させる。
-    await Future.delayed(Duration(seconds: 2));
+    try {
+      await Future.delayed(Duration(seconds: 2));
 
-    final user = FirebaseAuth.instance.currentUser;
+      final user = FirebaseAuth.instance.currentUser;
 
-    if (user == null) {
-      // FirebaseAuthからuserが取得できない場合は未ログインなため、notSignedIn状態。
-      state = const AsyncData(UserStatus.notSignedIn);
-      return;
+      if (user == null) {
+        // FirebaseAuthからuserが取得できない場合は未ログインなため、notSignedIn状態。
+        state = const AsyncData(UserStatus.notSignedIn);
+        return;
+      }
+      // ログイン済みのため、`UserStatus.signedIn` を設定
+      state = const AsyncData(UserStatus.signedIn);
+    } catch (e, stackTrace) {
+      state = AsyncError(e, stackTrace);
     }
-    // ログイン済みのため、`UserStatus.signedIn` を設定
-    state = const AsyncData(UserStatus.signedIn);
   }
 
   // エラー時など再読み込みさせるメソッド

--- a/lib/features/app_entry/controller/app_entry_controller.dart
+++ b/lib/features/app_entry/controller/app_entry_controller.dart
@@ -1,0 +1,41 @@
+import 'package:chat_app/features/app_entry/model/user_status.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+// `AppEntryController` を管理するプロバイダー
+// `StateNotifierProvider` を使用して、状態管理を行う
+final appEntryControllerProvider =
+    StateNotifierProvider<AppEntryController, AsyncValue<UserStatus>>(
+  (ref) => AppEntryController(),
+);
+
+// アプリのエントリー状態を管理する `StateNotifier` クラス
+// `AsyncValue<UserStatus>` を状態として扱い、非同期処理を管理する
+class AppEntryController extends StateNotifier<AsyncValue<UserStatus>> {
+  // 初期状態はローディング (`AsyncLoading()`) にし、初期化処理 `_initState()` を呼び出す
+  // AsyncValueにはloading・error・dataの3つの状態を持っている。
+  AppEntryController() : super(const AsyncLoading()) {
+    _initState();
+  }
+
+  Future<void> _initState() async {
+    // ローディング画面がわかりやすいように2秒遅延させる。
+    await Future.delayed(Duration(seconds: 2));
+
+    final user = FirebaseAuth.instance.currentUser;
+
+    if (user == null) {
+      // FirebaseAuthからuserが取得できない場合は未ログインなため、notSignedIn状態。
+      state = const AsyncData(UserStatus.notSignedIn);
+      return;
+    }
+    // ログイン済みのため、`UserStatus.signedIn` を設定
+    state = const AsyncData(UserStatus.signedIn);
+  }
+
+  // エラー時など再読み込みさせるメソッド
+  void refresh() {
+    state = const AsyncLoading();
+    _initState();
+  }
+}

--- a/lib/features/app_entry/model/user_status.dart
+++ b/lib/features/app_entry/model/user_status.dart
@@ -1,0 +1,5 @@
+enum UserStatus {
+  notSignedIn, // ログインが終わってない
+  notFinishedWalkThrough, // ログインは終わっているが、ウォークスルーが終わってない
+  signedIn, // ログインもウォークスルーも終わっている
+}

--- a/lib/features/app_entry/view/app_entry_view_widget.dart
+++ b/lib/features/app_entry/view/app_entry_view_widget.dart
@@ -1,0 +1,59 @@
+import 'package:chat_app/features/app_entry/model/user_status.dart';
+import 'package:chat_app/features/registration/view/concept_screen.dart';
+import 'package:chat_app/widgets/screen/error_screen.dart';
+import 'package:chat_app/widgets/screen/loading_screen.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class AppEntryViewWidget extends HookWidget {
+  const AppEntryViewWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final userStatus = useState<AsyncValue<UserStatus>>(const AsyncLoading());
+
+    Future<void> initState() async {
+      try {
+        // ローディングを見せるために2秒の遅延
+        await Future.delayed(const Duration(seconds: 2));
+
+        final user = FirebaseAuth.instance.currentUser;
+        if (user == null) {
+          userStatus.value = const AsyncData(UserStatus.notSignedIn);
+        } else {
+          userStatus.value = const AsyncData(UserStatus.signedIn);
+        }
+      } catch (e, stackTrace) {
+        userStatus.value = AsyncError(e, stackTrace);
+      }
+    }
+
+    useEffect(() {
+      // 画面表示時1度だけ初期化
+      initState();
+      return null;
+    }, []);
+
+    return userStatus.value.when(
+      loading: () => const LoadingScreen(),
+      error: (_, __) => ErrorScreen(
+        onRefresh: () {
+          userStatus.value = const AsyncLoading();
+          initState();
+        },
+      ),
+      data: (state) {
+        switch (state) {
+          case UserStatus.notSignedIn:
+            return const ConceptScreen();
+          case UserStatus.notFinishedWalkThrough:
+            return const Scaffold(body: Center(child: Text('ウォークスルー')));
+          case UserStatus.signedIn:
+            return const Scaffold(body: Center(child: Text('ログイン完了')));
+        }
+      },
+    );
+  }
+}

--- a/lib/features/app_entry/view/app_entry_widget.dart
+++ b/lib/features/app_entry/view/app_entry_widget.dart
@@ -1,0 +1,41 @@
+import 'package:chat_app/features/app_entry/controller/app_entry_controller.dart';
+import 'package:chat_app/features/app_entry/model/user_status.dart';
+import 'package:chat_app/features/registration/view/concept_screen.dart';
+import 'package:chat_app/widgets/screen/error_screen.dart';
+import 'package:chat_app/widgets/screen/loading_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+// Riverpod の `HookConsumerWidget` を使用し、状態を監視する
+class AppEntryWidget extends HookConsumerWidget {
+  const AppEntryWidget({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // `appEntryControllerProvider` の状態を監視
+    final asyncState = ref.watch(appEntryControllerProvider);
+
+    // 状態に応じて適切な画面を表示する
+    return asyncState.when(
+      error: (_, __) => ErrorScreen(
+        onRefresh: () {
+          // 再読み込みボタンでリフレッシュさせる。
+          ref.read(appEntryControllerProvider.notifier).refresh();
+        },
+      ),
+      // ローディング中の画面
+      loading: () => const LoadingScreen(),
+      // 正常にデータを取得した場合
+      data: (state) {
+        switch (state) {
+          case UserStatus.notSignedIn:
+            return const ConceptScreen();
+          case UserStatus.notFinishedWalkThrough:
+            return const Scaffold(body: Center(child: Text('ウォークスルー')));
+          case UserStatus.signedIn:
+            return const Scaffold(body: Center(child: Text('ログイン完了')));
+        }
+      },
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,8 @@
-import 'package:chat_app/features/registration/view/concept_screen.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import 'features/app_entry/view/app_entry_widget.dart';
 import 'firebase_options.dart';
 
 Future<void> main() async {
@@ -9,7 +10,11 @@ Future<void> main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
-  runApp(const MyApp());
+  runApp(
+    ProviderScope(
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
@@ -23,7 +28,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: ConceptScreen(),
+      home: AppEntryWidget(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import 'features/app_entry/view/app_entry_view_widget.dart';
 import 'features/app_entry/view/app_entry_widget.dart';
 import 'firebase_options.dart';
 
@@ -28,7 +29,8 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: AppEntryWidget(),
+      home: AppEntryViewWidget(),
+      // home: AppEntryWidget(),
     );
   }
 }

--- a/lib/widgets/screen/error_screen.dart
+++ b/lib/widgets/screen/error_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class ErrorScreen extends StatelessWidget {
+  const ErrorScreen({
+    super.key,
+    required this.onRefresh,
+  });
+
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: TextButton(
+          onPressed: onRefresh,
+          child: const Text('再読み込み'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/screen/loading_screen.dart
+++ b/lib/widgets/screen/loading_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class LoadingScreen extends StatelessWidget {
+  const LoadingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const PopScope(
+      canPop: false,
+      child: Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+        resizeToAvoidBottomInset: false,
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -134,6 +134,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_riverpod:
+    dependency: transitive
+    description:
+      name: flutter_riverpod
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -144,30 +152,38 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  hooks_riverpod:
+    dependency: "direct main"
+    description:
+      name: hooks_riverpod
+      sha256: "70bba33cfc5670c84b796e6929c54b8bc5be7d0fe15bb28c2560500b9ad06966"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.2"
+    version: "4.0.2"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -180,10 +196,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
+      sha256: "3315600f3fb3b135be672bf4a178c55f274bebe368325ae18462c89ac1e3b413"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "5.0.0"
   matcher:
     dependency: transitive
     description:
@@ -224,11 +240,19 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -241,10 +265,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:
@@ -257,10 +289,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -273,10 +305,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -297,10 +329,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:
@@ -310,5 +342,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.5.4 <4.0.0"
   flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.6.0
+  sdk: ^3.5.4
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -37,6 +37,7 @@ dependencies:
   flutter_hooks: ^0.20.5
   firebase_core: ^3.10.1
   firebase_auth: ^5.4.1
+  hooks_riverpod: ^2.6.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### 実装

アプリ起動時にユーザーのログイン状態を確認し適切な画面を表示する実装。


状態管理: riverpod　以下ライブラリはhookWidgetとRiverpodを扱えるライブラリ
https://pub.dev/packages/hooks_riverpod/install

ユーザーのステータス状態は以下の3つを想定
```dart
enum UserStatus {
  notSignedIn, // ログインが終わってない
  notFinishedWalkThrough, // ログインは終わっているが、プロフィール入力など途中離脱で終わっていない
  signedIn, // ログインもウォークスルーも終わっている
}
```


#### 挙動例


https://github.com/user-attachments/assets/ae64ca49-1cde-45d2-a477-672e0f405c2d

